### PR TITLE
Add OpenETA to multimodal embodied agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ language-conditioned robot world models, and embodied memory.
 - **CheckVLA: Execution-Time Verification with Action-Conditioned World Model for Long-Horizon Mobile Manipulation**  
   [![MMEA](https://img.shields.io/badge/-MMEA-A8DDA8?style=flat)](#-b-multimodal-embodied-agents) [![Paper](https://img.shields.io/badge/-Paper-E58A8F?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2607.26789)
 
+- **ETA: A New Agentic Paradigm for Embodied Tasks**  
+  [![MMEA](https://img.shields.io/badge/-MMEA-A8DDA8?style=flat-square)](#-b-multimodal-embodied-agents) [![Paper](https://img.shields.io/badge/-Paper-E58A8F?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.03924) [![Code](https://img.shields.io/github/stars/OpenMOSS/OpenETA?style=flat-square&logo=github&label=Code&color=B7CADB)](https://github.com/OpenMOSS/OpenETA) [![Project](https://img.shields.io/badge/-Project-9AC7E8?logo=googlechrome&logoColor=white&style=flat-square)](https://openmoss.ai/OpenETA/)
+
 - **RoboTTT: Context Scaling for Robot Policies**  
   [![MMEA](https://img.shields.io/badge/-MMEA-A8DDA8?style=flat)](#-b-multimodal-embodied-agents) [![Paper](https://img.shields.io/badge/-Paper-E58A8F?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2607.15275) [![Project](https://img.shields.io/badge/-Project-9AC7E8?logo=googlechrome&logoColor=white&style=flat-square)](https://research.nvidia.com/labs/gear/robottt/)
 


### PR DESCRIPTION
## What does this PR do?

Adds **ETA: A New Agentic Paradigm for Embodied Tasks** (OpenETA) to **B. Multimodal Embodied Agents**, with the arXiv paper, official code repository, and project page.

OpenETA couples multimodal task reasoning with physical execution through a Planner-Interface-World loop. The Planner selects tool calls, execution changes the environment, and fresh observations inform verification and subsequent decisions. It supports embodied interaction in simulation and on real robots, matching section B's task-level closed-loop scope.

**First public release:** 2026-07-25 (2026.07), as recorded in the [official repository's What's New section](https://github.com/OpenMOSS/OpenETA#whats-new). The [arXiv paper](https://arxiv.org/abs/2608.03924) was first submitted on 2026-08-04. The entry is ordered by the earlier public release, after CheckVLA (2026-07-29) and before RoboTTT (2026-07-16).

## Papers added

- **ETA: A New Agentic Paradigm for Embodied Tasks**  
  [![MMEA](https://img.shields.io/badge/-MMEA-A8DDA8?style=flat-square)](#-b-multimodal-embodied-agents) [![Paper](https://img.shields.io/badge/-Paper-E58A8F?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.03924) [![Code](https://img.shields.io/github/stars/OpenMOSS/OpenETA?style=flat-square&logo=github&label=Code&color=B7CADB)](https://github.com/OpenMOSS/OpenETA) [![Project](https://img.shields.io/badge/-Project-9AC7E8?logo=googlechrome&logoColor=white&style=flat-square)](https://openmoss.ai/OpenETA/)

## Checklist

- [x] Entry follows the current two-line format in CONTRIBUTING.md, including two trailing spaces after the title.
- [x] Correct section badge first; new badges use `flat-square`.
- [x] No author, affiliation, venue, date, PAPAV stage label, topic tag, or template value in the README entry.
- [x] Not already listed elsewhere in the README.
- [x] Paper, official code, and official project links resolve; the Code badge targets the repository root.
- [x] Paper appears in exactly one section, ordered by its first public release.
- [x] Release date and placement rationale are included above.
- [x] No sections were added or renamed; no Contents update is needed.

The PR template still refers to an older three-line format; this addition follows the current CONTRIBUTING.md. The section badge uses the existing README's `#-b-multimodal-embodied-agents` anchor, verified against GitHub's rendered heading.

